### PR TITLE
Link to Solibri Developer Platform main page from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # api-examples
-Solibri Developer Platform APIs examples
+[Solibri Developer Platform](https://solibri.github.io/Developer-Platform/) APIs examples
 
 ## Licensing
 


### PR DESCRIPTION
Added a link to README.md so readers can navigate to the SDP main page