### PR TITLE
Update Maven dependencies of view examples

### DIFF
--- a/view-examples/pom.xml
+++ b/view-examples/pom.xml
@@ -20,7 +20,9 @@
 		<slf4j-api.version>1.7.15</slf4j-api.version>
 		<javafx.version>14.0.1</javafx.version>
 		<poi.version>4.1.2</poi.version>
-		<google-http-client.version>1.39.2-sp.1</google-http-client.version>
+		<google-http-client.version>1.42.2</google-http-client.version>
+		<google.client.version>1.34.1</google.client.version>
+		<google-api-client.version>2.0.0</google-api-client.version>
 		<httpclient.version>4.5.13</httpclient.version>
 		<sqlite-jdbc.version>3.36.0.3</sqlite-jdbc.version>
 	</properties>
@@ -39,6 +41,16 @@
 			</properties>
 		</profile>
 	</profiles>
+	
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>com.google.http-client</groupId>
+				<artifactId>google-http-client-gson</artifactId>
+				<version>${google-http-client.version}</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
 	<dependencies>
 		<dependency>
@@ -76,16 +88,6 @@
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
 			<version>${httpclient.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>commons-codec</groupId>
-					<artifactId>commons-codec</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.httpcomponents</groupId>
-					<artifactId>httpcore</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>com.google.http-client</groupId>
@@ -125,7 +127,7 @@
 		<dependency>
 			<groupId>com.google.api-client</groupId>
 			<artifactId>google-api-client</artifactId>
-			<version>1.31.5</version>
+			<version>${google-api-client.version}</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.apache.httpcomponents</groupId>
@@ -148,7 +150,7 @@
 		<dependency>
 			<groupId>com.google.http-client</groupId>
 			<artifactId>google-http-client-jackson2</artifactId>
-			<version>1.31.0</version>
+			<version>${google.client.version}</version>
 			<exclusions>
 				<exclusion>
 					<groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Update maven dependencies for view examples version 9.13.0
- Update google-http-client from1.39.2-sp.1 to 1.42.2
- Update  google.client from 1.31.0 to 1.34.1
- Update  google-api-client from 1.31.5 to  2.0.0
- Removed exclusions in httpclient (commons-codec & httpcore)