### PR TITLE
Update Maven dependencies of view examples after release of 9.13.3

### DIFF
--- a/view-examples/pom.xml
+++ b/view-examples/pom.xml
@@ -22,9 +22,9 @@
 		<poi.version>4.1.2</poi.version>
 		<google-http-client.version>1.42.2</google-http-client.version>
 		<google.client.version>1.34.1</google.client.version>
-		<google-api-client.version>2.0.0</google-api-client.version>
+		<google-api-client.version>2.2.0</google-api-client.version>
 		<httpclient.version>4.5.14</httpclient.version>
-		<sqlite-jdbc.version>3.36.0.3</sqlite-jdbc.version>
+		<sqlite-jdbc.version>3.41.2.1</sqlite-jdbc.version>
 	</properties>
 
 	<profiles>


### PR DESCRIPTION
Update maven dependencies for view examples version 9.13.3
- Update google-api-client from 2.0.0 to 2.2.0
- Update sqlite-jdbc from 3.36.0.3 to 3.41.2.1